### PR TITLE
Fix bn_subb_word macro

### DIFF
--- a/calc_addrs.cl
+++ b/calc_addrs.cl
@@ -371,7 +371,7 @@ bn_uadd_words_c_seq(bn_word *r, bn_word *a, __constant bn_word *b)
 
 #define bn_subb_word(r, a, b, t, c) do {	\
 		t = a - (b + c);		\
-		c = (!(a) && c) ? 1 : 0;	\
+		c = ((!a | (a == b)) & c) ? 1 : 0;	\
 		c |= (a < b) ? 1 : 0;		\
 		r = t;				\
 	} while (0)


### PR DESCRIPTION
Add missing second borrow, as suggested by @mladenmarkov in #43.